### PR TITLE
docs(character): 修正 imageInputMaxSize 单位描述

### DIFF
--- a/docs/ecosystem/other/character.md
+++ b/docs/ecosystem/other/character.md
@@ -461,7 +461,7 @@ input 会把最近群聊的聊天记录和状态等信息作为格式化输入�
 * `toolCalling`: 是否启用工具调用功能
 * `image`: 是否允许输入图片
 * `imageInputMaxCount`: 最大的输入图片数量
-* `imageInputMaxSize`: 最大的输入图片大小（KB）
+* `imageInputMaxSize`: 最大的输入图片大小（MB）
 * `coolDownTime`: 冷却发言时间（秒）
 * `typingTime`: 模拟打字时的间隔（毫秒）
 * `largeTextSize`: 大文本消息的判断阈值（每段分句的字符数）


### PR DESCRIPTION
## 变更说明
- 修正文档中 `chatluna-character` 分群配置列表对 `imageInputMaxSize` 的单位描述。
- 将 `KB` 更正为 `MB`，与同页上方配置说明保持一致。

## 修改文件
- `docs/ecosystem/other/character.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated imageInputMaxSize unit specifications from kilobytes to megabytes in global and per-group configuration documentation sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->