### PR TITLE
docs(character): 同步默认预设说明文案

### DIFF
--- a/docs/public/resources/character_preset.yml
+++ b/docs/public/resources/character_preset.yml
@@ -34,12 +34,15 @@
 #           - 不建议使用容器在宿主机的内网IP连接，因为容器的内网IP可能会在重启后重新分配，导致原有连接断开
 #       - 其他部署：
 #          - 其他部署方案（如Windows），请尝试保持默认地址“http://127.0.0.1:5140”，不要修改
-# - chatluna-google-gemini-adapter（可选，使用Gemini系列时推荐）
-#   - 插件用途：提供Gemini模型接入
+# - chatluna-google-gemini-adapter（可选，使用 Gemini 系列时推荐）
+#   - 插件用途：提供 Gemini 模型接入
 #   - 配置说明：
-#     - 可选开启“为模型启用文件读取工具”，允许模型读取文件内容（含视频）
-#       - 此功能暂未被合并到主分支中，敬请期待
-#     - 使用文件读取工具时，建议同时安装chatluna-storage-service，优先传入稳定的存储链接，避免临时链接过期导致读取失败
+#     - Gemini API 请求地址末尾需添加 v1beta
+# - chatluna-multimodal-service（可选，使用 Gemini 或不支持图像输入的模型时推荐）
+#   - 插件用途：提供图像描述服务、图像及文件（含视频）读取/描述工具
+#   - 配置说明：
+#     - 若使用 Gemini，可以启用 enableImageReadTool、enableFileReadTool
+#     - 若使用不支持图像输入的模型（如 DeepSeek），可以启用 enableContextImageDescription、enableImageReadTool，并在图像描述服务设置中配置一个支持图像输入的模型以生成图像描述
 # - emojiluna
 #   - 插件用途：提供表情包发送功能，建议自行准备一张“拒绝”类型的表情包
 #   - 配置说明：
@@ -219,6 +222,7 @@ system: |
       - 回复不超过30字
       - 如果一句话比较长，就将整句话分为多个消息发送，比如“<message>诶……这个嘛</message><message>这我就不知道了（）</message>”
       - 消息末尾通常不加句号（无论是。还是.都不加），就像正常发消息聊天一样
+    - 格式：纯文本，不在回复中使用Markdown、LaTeX，除非另有要求
     - 玩笑/尴尬：
       - 可选择性地偶尔在句尾加“（）”，但不要反复在句尾加括号，会显得很刻意
       - 当你想故意营造节目效果时，不加括号能让语气看起来理直气壮（确信）


### PR DESCRIPTION
## 变更摘要
- 同步更新 `character_preset.yml` 默认预设说明。
- 增补 `chatluna-multimodal-service` 推荐配置说明。
- 调整部分回复格式与玩笑风格表述，使文案与当前默认预设一致。
