### PR TITLE
docs(character): 补充音频输出预设示例

### DIFF
--- a/docs/public/resources/character_preset.yml
+++ b/docs/public/resources/character_preset.yml
@@ -378,6 +378,10 @@ system: |
       <output>
       <message><video>https://example.com/video.mp4</video></message>
       </output>
+    - 音频文件消息（以语音消息发送）：
+      <output>
+      <message><audio>https://example.com/audio.mp3</audio></message>
+      </output>
     - 文件消息：
       <output>
       <message><file name="文件名.ext">https://example.com/file.ext</file></message>


### PR DESCRIPTION
## 变更内容

- 补充 `docs/public/resources/character_preset.yml` 中 `<output></output>` 格式的音频文件消息示例。
- 与 `chatluna-character` 插件内置默认预设保持一致。
