### PR TITLE
docs(character): 简化转发插件协议说明

### DIFF
--- a/docs/public/resources/character_preset.yml
+++ b/docs/public/resources/character_preset.yml
@@ -11,7 +11,7 @@
 # - chatluna-forward-msg
 #   - 插件用途：提供合并转发记录读取、发送功能
 #   - 配置说明：
-#     - 在“协议选择”中启用“NapCat OneBot”或“LLBot OneBot”中你使用的协议
+#     - 在“协议选择”中选择你使用的协议
 #     - 在“图片描述服务”中选择一个多模态模型
 #     - 在 chatluna 插件的“对话行为选项”中启用：attachForwardMsgIdToContext
 #     - 在 chatluna-character 插件对应会话配置的“上下文”中启用：enableMessageId

--- a/docs/public/resources/character_preset_tool_call.yml
+++ b/docs/public/resources/character_preset_tool_call.yml
@@ -11,7 +11,7 @@
 # - chatluna-forward-msg
 #   - 插件用途：提供合并转发记录读取、发送功能
 #   - 配置说明：
-#     - 在“协议选择”中启用“NapCat OneBot”或“LLBot OneBot”中你使用的协议
+#     - 在“协议选择”中选择你使用的协议
 #     - 在“图片描述服务”中选择一个多模态模型
 #     - 在 chatluna 插件的“对话行为选项”中启用：attachForwardMsgIdToContext
 #     - 在 chatluna-character 插件对应会话配置的“上下文”中启用：enableMessageId


### PR DESCRIPTION
## 摘要
- 简化两个 character 预设中 chatluna-forward-msg 的协议选择说明。
- 避免限定具体 OneBot 协议名称。

## 校验
- `git diff --check`
